### PR TITLE
Add support for CC=gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+CC=clang
 CURL_CFLAGS = $(shell curl-config --cflags)
 CURL_LIBS = $(shell curl-config --libs)
 
 out/weer: $(wildcard src/*.c src/*.h)
 	mkdir -p out
-	clang -o out/weer -g -Wall -Werror -Wextra -Wpedantic $(CURL_CFLAGS) $(CURL_LIBS) $(wildcard src/*.c)
+	$(CC) -o out/weer -g -Wall -Werror -Wextra -Wpedantic  $(wildcard src/*.c) $(CURL_CFLAGS) $(CURL_LIBS)
 
 all: clean out/weer
 


### PR DESCRIPTION
Adds and overridable CC variable that defaults to the currently
hard-coded clang.

Also moves the linker flags to *after* the source file pattern match.
GCC will fail to compile due to undefined reference errors if the linker
flags come before a source file in which the associated functions are
used.